### PR TITLE
Refactor: Switch Prisma to Axios in Edit Entity Form

### DIFF
--- a/app/forms/entity/edit/[id]/page.tsx
+++ b/app/forms/entity/edit/[id]/page.tsx
@@ -1,7 +1,6 @@
 import axios from "axios";
 import dynamic from "next/dynamic";
 import { notFound } from "next/navigation";
-import prisma from "@/prisma/client";
 
 const EntityForm = dynamic(() => import("@/app/forms/entity/EntityForm"), {
   ssr: false,
@@ -13,11 +12,15 @@ interface Props {
 }
 
 const EditEntityPage = async ({ params }: Props) => {
-  const entity = await prisma.entity.findUnique({
-    where: { id: params.id },
-  });
-  if (!entity) return notFound();
-  return <EntityForm entity={entity} />;
+  try {
+    const entity = await axios.get(
+      `${process.env.APP_DOMAIN}/api/entity/${params.id}`
+    );
+    if (!entity) return notFound();
+    return <EntityForm entity={entity.data} />;
+  } catch (error) {
+    return notFound();
+  }
 };
 
 export default EditEntityPage;


### PR DESCRIPTION
Replaced Prisma `findUnique` with Axios to route requests through the API, aligning with future security enhancements like authentication and API keys. This change ensures that any security measures implemented in the API will also apply to the edit form. 
[See issue #7 ](https://github.com/tneiman19/service-signal-tracker/issues/7#issue-2034801809)